### PR TITLE
Rearrange status checks

### DIFF
--- a/src/Models/Subscription.php
+++ b/src/Models/Subscription.php
@@ -144,14 +144,14 @@ class Subscription extends Model
             return self::STATUS_TRAILLING;
         }
 
-        if ($this->isActive()) {
-            return self::STATUS_ACTIVE;
-        }
-
         if ($this->isCancelled()) {
             return self::STATUS_CANCELLED;
         }
-
+        
+        if ($this->isActive()) {
+            return self::STATUS_ACTIVE;
+        }
+        
         if ($this->isOverdue()) {
             return self::STATUS_OVERDUE;
         }

--- a/src/Models/Subscription.php
+++ b/src/Models/Subscription.php
@@ -147,11 +147,11 @@ class Subscription extends Model
         if ($this->isCancelled()) {
             return self::STATUS_CANCELLED;
         }
-        
+
         if ($this->isActive()) {
             return self::STATUS_ACTIVE;
         }
-        
+
         if ($this->isOverdue()) {
             return self::STATUS_OVERDUE;
         }


### PR DESCRIPTION
rearrange the checks for status on the subscription model to evaluate cancelled condition first. this ensures that the active status is only returned when a subscription is not cancelled